### PR TITLE
Allow cross-origin resource sharing

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,14 @@ var events = require('./routes/events');
 app.use(bodyParser.json({type: 'application/json'}));
 app.use(bodyParser.urlencoded({extended: true}));
 
+// Enable cross-origin resource sharing (CORS)
+app.use(function(req, res, next) {
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE");
+  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  next();
+});
+
 app.get('/', function(req, res) {
   res.status(405);
   res.send('Route not implemented');

--- a/app.js
+++ b/app.js
@@ -19,9 +19,9 @@ app.use(bodyParser.urlencoded({extended: true}));
 
 // Enable cross-origin resource sharing (CORS)
 app.use(function(req, res, next) {
-  res.header("Access-Control-Allow-Origin", "*");
-  res.header("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE");
-  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
+  res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
   next();
 });
 


### PR DESCRIPTION
Web app team couldn't access our API. We need to allow cross origin resource sharing.